### PR TITLE
add httparty to gem dependency because it is require to use the gem

### DIFF
--- a/stubhub.gemspec
+++ b/stubhub.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  gem.add_dependency('httparty')
   gem.add_development_dependency 'httparty'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'vcr'


### PR DESCRIPTION
require 'stubhub'
LoadError: cannot load such file -- httparty
